### PR TITLE
修改：功能：迁移 Lemwood API 到 v2 并适配统一数据信封

### DIFF
--- a/data/content/trafficConfig.json
+++ b/data/content/trafficConfig.json
@@ -104,6 +104,24 @@
           "maxTicksLimit": 10,
           "yBeginAtZero": false
         }
+      },
+      {
+        "id": "way10Traffic",
+        "label": "总流量消耗",
+        "color": "rgba(153, 102, 255, 1)",
+        "dataPath": "data.total_traffic_bytes",
+        "formatBytes": true,
+        "style": {
+          "fill": true,
+          "tension": 0,
+          "pointRadius": 2,
+          "pointHoverRadius": 5,
+          "borderWidth": 2,
+          "backgroundColor": "rgba(153, 102, 255, 0.1)",
+          "xGridDisplay": false,
+          "maxTicksLimit": 10,
+          "yBeginAtZero": false
+        }
       }
     ]
   }

--- a/data/content/trafficConfig.json
+++ b/data/content/trafficConfig.json
@@ -65,7 +65,7 @@
   {
     "id": "way10",
     "name": "线路10",
-    "apiUrl": "https://miawa.cn/api/stats",
+    "apiUrl": "https://miawa.cn/api/v2/stats",
     "refreshInterval": 300000,
     "refreshLabel": "每5分钟更新",
     "charts": [
@@ -73,7 +73,7 @@
         "id": "way10Visit",
         "label": "总访问次数",
         "color": "rgba(54, 162, 235, 1)",
-        "dataPath": "total_visits",
+        "dataPath": "data.total_visits",
         "formatBytes": false,
         "style": {
           "fill": true,
@@ -91,7 +91,7 @@
         "id": "way10Download",
         "label": "总下载次数",
         "color": "rgba(255, 159, 64, 1)",
-        "dataPath": "total_downloads",
+        "dataPath": "data.total_downloads",
         "formatBytes": false,
         "style": {
           "fill": true,

--- a/data/down/amethyst-android/index.json
+++ b/data/down/amethyst-android/index.json
@@ -5,7 +5,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/aamc",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/aamc",
     "apiVer": "Lemwood"
   }
 ]

--- a/data/down/fcl/index.json
+++ b/data/down/fcl/index.json
@@ -33,7 +33,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/fcl",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/fcl",
     "apiVer": "Lemwood",
     "default": true
   },

--- a/data/down/hmcl/index.json
+++ b/data/down/hmcl/index.json
@@ -6,7 +6,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/hmcl",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/hmcl",
     "apiVer": "Lemwood"
   }
 ]

--- a/data/down/renderer/index.json
+++ b/data/down/renderer/index.json
@@ -19,7 +19,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/MG",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/MG",
     "apiVer": "Lemwood"
   }
 ]

--- a/data/down/vulkan/index.json
+++ b/data/down/vulkan/index.json
@@ -9,7 +9,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/FCL_Turnip",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/FCL_Turnip",
     "apiVer": "Lemwood"
   }
 ]

--- a/data/down/zl/index.json
+++ b/data/down/zl/index.json
@@ -6,7 +6,7 @@
 
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/zl",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/zl",
     "apiVer": "Lemwood"
   }
 ]

--- a/data/down/zl2/index.json
+++ b/data/down/zl2/index.json
@@ -15,7 +15,7 @@
   },
   {
     "name": "线路10",
-    "nextUrl": "https://miawa.cn/api/status/zl2",
+    "nextUrl": "https://miawa.cn/api/v2/launchers/zl2",
     "apiVer": "Lemwood",
     "default": true,
     "filter": [".apk"]

--- a/js/module/tab4.js
+++ b/js/module/tab4.js
@@ -273,6 +273,8 @@ function xf_createOrUpdateChart(canvasId, records, chartConfig, tooltipCallback,
  * @returns {*}
  */
 function xf_getValueByPath(obj, path) {
+  if (!path) return undefined;
+
   // 先尝试用方括号匹配：p[1] → obj.p[1]
   const bracketMatch = path.match(/^([^[]+)\[(\d+)\]$/);
   if (bracketMatch) {
@@ -280,6 +282,12 @@ function xf_getValueByPath(obj, path) {
     const index = parseInt(bracketMatch[2], 10);
     return obj?.[key]?.[index];
   }
+
+  // 支持点号路径：data.total_visits
+  if (path.includes('.')) {
+    return path.split('.').reduce((current, key) => current?.[key], obj);
+  }
+
   // 否则直接当属性名
   return obj?.[path];
 }

--- a/js/module/transformApiData.js
+++ b/js/module/transformApiData.js
@@ -195,7 +195,9 @@ export default class transformApiData {
    * @returns {Array} 转换后的数据
    */
   static transformLemwoodApiData(data, latest) {
-    return data.map(item => ({
+    // 适配 v2 统一信封 {data, error, meta}
+    const payload = data?.data ?? data;
+    return payload.map(item => ({
       name: item.name,
       default: item.name === latest,
       children: item.assets?.map(asset => ({
@@ -212,7 +214,9 @@ export default class transformApiData {
    * @returns {Array} 转换后的数据
    */
   static transformLemwoodLatestApiData(data) {
-    return this.transformLemwoodApiData([data]);
+    // 适配 v2 统一信封 {data, error, meta}
+    const payload = data?.data ?? data;
+    return this.transformLemwoodApiData([payload]);
   }
 
   /**
@@ -239,7 +243,7 @@ export default class transformApiData {
       console.warn('选择器模块：Lemwood线：latest：选择器的文本不在映射中');
       return null;
     }
-    const latest = await loadContent.fetchItems(`https://miawa.cn/api/latest/${selectName}`, 'text');
+    const latest = await loadContent.fetchItems(`https://miawa.cn/api/v2/latest/${selectName}`, 'text');
     console.log(`选择器模块：Lemwood线：latest：${latest}`);
     return latest;
   }

--- a/js/module/utils.js
+++ b/js/module/utils.js
@@ -10,8 +10,8 @@ export default class utils {
     if (bytes === 0) return '0 Bytes';
 
     const k = 1024;
-    const sizes = ['Bytes', 'KiB', 'MiB', 'GiB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   }

--- a/versionInfo.json
+++ b/versionInfo.json
@@ -1,3 +1,3 @@
 {
-  "git": "03aca1f283591573699a67b9c8a88842d1c0fa7c"
+  "git": "099dd92ba76636db8cb67b4a3f51177a3c22effa"
 }


### PR DESCRIPTION
## 变更内容

- 将 Lemwood 相关接口从 v1 迁移到 v2：
  - /api/stats → /api/v2/stats（线路10流量监控）
  - /api/status/{launcher} → /api/v2/launchers/{launcher}（FCL/ZL/ZL2/HMCL/渲染器/Vulkan/Amethyst）
  - /api/latest/{launcher} → /api/v2/latest/{launcher}（获取默认版本）
- 	ab4.js 的 xf_getValueByPath 新增点号路径支持，适配 v2 统一信封 {data, error, meta}`n- 	ransformApiData.js 的 Lemwood 转换函数解包 v2 信封，修复 data.map is not a function 错误

## 验证

- 所有修改的 JSON 文件语法校验通过
- 	ransformLemwoodApiData 对 v2 信封格式测试通过
- 本地 python -m http.server 预览正常